### PR TITLE
Support error instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 You can't use `throw` statement in expressions in JavaScript:
 
 ```js
-arg = arg || throw new Error('arg is required'); 
+arg = arg || throw new Error('arg is required');
 // => SyntaxError: Unexpected token throw
 ```
 
@@ -14,13 +14,19 @@ var thr = require('throw');
 
 // ...
 
-arg = arg || thr('arg is required'); 
+arg = arg || thr('arg is required');
 ```
 
 Messages can contain `printf`-like placeholders:
 
 ```js
-arg = arg || thr('"%s" is required', argName); 
+arg = arg || thr('"%s" is required', argName);
+```
+
+You can specify instance of `Error` instead of message:
+
+```js
+arg = arg || thr(new Error('arg is required'));
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ You can specify instance of `Error` instead of message:
 arg = arg || thr(new Error('arg is required'));
 ```
 
+Or parametrize error class:
+
+```js
+arg = arg || thr(Error, 'arg is required');
+```
+
 ## Installation
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -3,12 +3,21 @@ var format = require('util').format;
 /**
  * Function wrapper for throw statement.
  * Throw an error with formatted message.
- * @param {Error|String} error — instance of error or error message.
+ * @param {Error|Function|String} error — instance of error, error class or error message.
  * @throws
  */
 module.exports = function(error) {
     if (error instanceof Error) {
         throw error;
+    }
+
+    if (typeof error === 'function') {
+            // get arguments except the first
+        var args = Array.prototype.slice.call(arguments, 1),
+            // create instance of specified error class with specified arguments
+            err = new (Function.prototype.bind.apply(error, [null].concat(args)))();
+
+        throw err;
     }
 
     throw new Error(format.apply(null, arguments));

--- a/index.js
+++ b/index.js
@@ -3,9 +3,13 @@ var format = require('util').format;
 /**
  * Function wrapper for throw statement.
  * Throw an error with formatted message.
- * @param {String} errorMessage
+ * @param {Error|String} error — instance of error or error message.
  * @throws
  */
-module.exports = function(errorMessage) {
+module.exports = function(error) {
+    if (error instanceof Error) {
+        throw error;
+    }
+
     throw new Error(format.apply(null, arguments));
 };


### PR DESCRIPTION
Sometimes it is necessary to report error with the help of special custom error.

Example:

``` js
var thr = require('throw');

// Create a new object, that prototypally inherits from the Error constructor
function MyError(message) {
  this.name = 'MyError';
  this.message = message || 'Default Message';
  this.stack = (new Error(message)).stack;
}
MyError.prototype = Object.create(Error.prototype);
MyError.prototype.constructor = MyError;

var arg = arg || thr(new MyError());
```
